### PR TITLE
Remove logger name with the updated react-inspector.

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "mantra-core": "^1.6.1",
     "qs": "^6.2.0",
     "react-fuzzy": "^0.2.3",
-    "react-inspector": "^1.0.1",
+    "react-inspector": "^1.1.0",
     "react-modal": "^1.2.1",
     "redux": "^3.5.2"
   },

--- a/src/modules/ui/components/action_logger/index.js
+++ b/src/modules/ui/components/action_logger/index.js
@@ -67,12 +67,6 @@ const countWrapper = {
   marginRight: 5,
 };
 
-const actionNameStyle = {
-  float: 'right',
-  padding: '0 5px',
-  fontWeight: 'bold',
-};
-
 class ActionLogger extends Component {
   componentDidUpdate() {
     if (this.refs.latest) {
@@ -99,7 +93,6 @@ class ActionLogger extends Component {
                 data={action.data.args || action.data}
               />
             </div>
-            <span style={actionNameStyle}>{action.data.name}</span>
           </div>
       );});
   }


### PR DESCRIPTION
With the latest react-inspector it'll show the name at the beginning.
See: https://github.com/kadirahq/storybook-ui/pull/11#issuecomment-232229912

So, we don't need to show the name. Just need to remove it.
This is how it's looks now.

![screen shot 2016-07-20 at 11 30 06 am](https://cloud.githubusercontent.com/assets/50838/16976582/60ba1356-4e6d-11e6-8ac5-321162baca2f.png)
