### PR TITLE
added documentation for APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,54 @@ Then you'll get a UI like this:
 
 > **See the [example](/example) app for a complete example.**
 
+## API
+
+### .setOptions([option])
+
+```js
+//-------------
+handleAPI(api) {
+  api.setOptions{
+    name: 'My Component', // change the name displayed in the left top portion
+    url: 'https://github.com/user/my-component' // change its URL
+  }
+}
+```
+
+## .setStories([stories])
+
+This API is used to pass the`kind` and `stories` list to storybook-ui.
+
+```js
+handleAPI(api) {
+  api.setStories([
+    {
+      kind: 'Component 1',
+      stories: ['State 1', 'State 2']
+    },
+
+    {
+      kind: 'Component 2',
+      stories: ['State a', 'State b']
+    }
+  ]
+}
+```
+
+## .onStory()
+
+You can use to listen to the story change and update the preview.
+
+```js
+handleAPI(api) {
+  api.onStory((kind, story) => {
+      this.globalState.emit('change', kind, story);
+  });
+}
+```
+
+
+
 ## Hacking Guide
 
 If you like to add features to the Storybook UI or fix bugs, this is the guide you need to follow.


### PR DESCRIPTION
`.setOptions` is implemented in storybook-ui so we can use it to manually to set name and URL of react-storybook. I thought this may not have been implemented because maybe that PR would have been missed. There are a lot of things missing in the documentation even in react storybook. So I thought I would add as much as I know here. Add something if it's missing. Development will be easier.