### PR TITLE
Add 'setQueryParams' and 'getQueryParams' to api

### DIFF
--- a/example/client/provider.js
+++ b/example/client/provider.js
@@ -14,25 +14,6 @@ const style = {
   justifyContent: 'center',
 };
 
-const panels = {
-  test1: {
-    title: 'Test 1',
-    render: () => <div style={style}>I</div>,
-  },
-  test2: {
-    title: 'Test 2',
-    render: () => <div style={style}>II</div>,
-  },
-  test3: {
-    title: 'Test 3',
-    render: () => <div style={style}>III</div>,
-  },
-  test4: {
-    title: 'Test 4',
-    render: () => <div style={style}>IV</div>,
-  },
-}
-
 export default class ReactProvider extends Provider {
   constructor() {
     super();
@@ -40,6 +21,35 @@ export default class ReactProvider extends Provider {
   }
 
   getPanels() {
+    const panels = {
+      test1: {
+        title: 'Test 1',
+        render: () => {
+          let inp;
+          return (
+            <div style={style}>
+              <input
+                ref={i => {inp=i}}
+                value={this.api.getQueryParam("text")===undefined ? 'ONE' : this.api.getQueryParam("text")}
+                onChange={() => {this.api.setQueryParams({text: inp.value})}}>
+              </input>
+            </div>
+          );
+        },
+      },
+      test2: {
+        title: 'Test 2',
+        render: () => <div style={style}>II</div>,
+      },
+      test3: {
+        title: 'Test 3',
+        render: () => <div style={style}>III</div>,
+      },
+      test4: {
+        title: 'Test 4',
+        render: () => <div style={style}>IV</div>,
+      },
+    }
     return panels;
   }
 

--- a/src/modules/api/actions/__tests__/api.js
+++ b/src/modules/api/actions/__tests__/api.js
@@ -70,4 +70,22 @@ describe('manager.api.actions.api', () => {
       });
     });
   });
+
+  describe('setQueryParams', () => {
+    it('should dispatch related redux action', () => {
+      const reduxStore = {
+        dispatch: sinon.stub(),
+      };
+      const customQueryParams = {
+        foo: 'bar',
+      };
+
+      actions.setQueryParams({ reduxStore }, customQueryParams);
+      const a = reduxStore.dispatch.args[0][0];
+      expect(a).to.deep.equal({
+        type: types.SET_QUERY_PARAMS,
+        customQueryParams,
+      });
+    });
+  });
 });

--- a/src/modules/api/actions/api.js
+++ b/src/modules/api/actions/api.js
@@ -29,4 +29,11 @@ export default {
       options,
     });
   },
+
+  setQueryParams({ reduxStore }, customQueryParams) {
+    reduxStore.dispatch({
+      type: types.SET_QUERY_PARAMS,
+      customQueryParams,
+    });
+  },
 };

--- a/src/modules/api/actions/index.js
+++ b/src/modules/api/actions/index.js
@@ -4,6 +4,7 @@ export const types = {
   SELECT_STORY: 'API_SELECT_STORY',
   JUMP_TO_STORY: 'API_JUMP_TO_STORY',
   SET_OPTIONS: 'API_SET_OPTIONS',
+  SET_QUERY_PARAMS: 'API_SET_QUERY_PARAMS',
 };
 
 import api from './api';

--- a/src/modules/api/configs/__tests__/init_api.js
+++ b/src/modules/api/configs/__tests__/init_api.js
@@ -9,6 +9,7 @@ describe('manager.api.config.initApi', () => {
       api: {
         setStories: sinon.stub(),
         selectStory: sinon.stub(),
+        setQueryParams: sinon.stub(),
       },
       shortcuts: {
         handleEvent: sinon.stub(),
@@ -25,6 +26,7 @@ describe('manager.api.config.initApi', () => {
         expect(api.selectStory).to.be.equal(actions.api.selectStory);
         expect(api.handleShortcut).to.be.equal(actions.shortcuts.handleEvent);
         expect(typeof api.onStory).to.be.equal('function');
+        expect(typeof api.setQueryParams).to.be.equal('function');
         done();
       },
     };
@@ -114,5 +116,33 @@ describe('manager.api.config.initApi', () => {
     initApi(provider, reduxStore, actions);
     // calling the subscription
     reduxStore.subscribe.args[0][0]();
+  });
+
+  describe('getQueryParam', () => {
+    it('should return the correct query param value', (done) => {
+      const actions = { api: {}, shortcuts: {} };
+
+      const reduxStore = {
+        subscribe: sinon.stub(),
+        getState: () => ({
+          api: {
+            customQueryParams: {
+              foo: 'foo value',
+              bar: 'bar value',
+            },
+          },
+        }),
+      };
+
+      const provider = {
+        handleAPI(api) {
+          const value = api.getQueryParam('foo');
+          expect(value).to.be.equal('foo value');
+          done();
+        },
+      };
+
+      initApi(provider, reduxStore, actions);
+    });
   });
 });

--- a/src/modules/api/configs/init_api.js
+++ b/src/modules/api/configs/init_api.js
@@ -15,6 +15,15 @@ export default function (provider, reduxStore, actions) {
     selectStory: actions.api.selectStory,
     setOptions: actions.api.setOptions,
     handleShortcut: actions.shortcuts.handleEvent,
+    setQueryParams: actions.api.setQueryParams,
+
+    getQueryParam(key) {
+      const { api } = reduxStore.getState();
+      if (api.customQueryParams) {
+        return api.customQueryParams[key];
+      }
+      return undefined;
+    },
   };
 
   provider.handleAPI(providerApi);

--- a/src/modules/api/configs/reducers/__tests__/api.js
+++ b/src/modules/api/configs/reducers/__tests__/api.js
@@ -275,3 +275,27 @@ describe('SET OPTIONS', () => {
     expect(newState.options).to.eql(expected);
   });
 });
+
+describe('SET_QUERY_PARAMS', () => {
+  it('should set custom query params merging with the existing ones', () => {
+    const customQueryParams = {
+      fooParams: 'foo',
+      barParams: 'bar',
+    };
+
+    const action = {
+      type: types.SET_QUERY_PARAMS,
+      customQueryParams: {
+        fooParams: 'baz',
+      },
+    };
+
+    const expected = {
+      fooParams: 'baz',
+      barParams: 'bar',
+    };
+
+    const newState = reducer({ customQueryParams }, action);
+    expect(newState.customQueryParams).to.eql(expected);
+  });
+});

--- a/src/modules/api/configs/reducers/__tests__/api.js
+++ b/src/modules/api/configs/reducers/__tests__/api.js
@@ -298,4 +298,25 @@ describe('SET_QUERY_PARAMS', () => {
     const newState = reducer({ customQueryParams }, action);
     expect(newState.customQueryParams).to.eql(expected);
   });
+
+  it('should unset custom query params when the value is null', () => {
+    const customQueryParams = {
+      fooParams: 'foo',
+      barParams: 'bar',
+    };
+
+    const action = {
+      type: types.SET_QUERY_PARAMS,
+      customQueryParams: {
+        fooParams: null,
+      },
+    };
+
+    const expected = {
+      barParams: 'bar',
+    };
+
+    const newState = reducer({ customQueryParams }, action);
+    expect(newState.customQueryParams).to.eql(expected);
+  });
 });

--- a/src/modules/api/configs/reducers/api.js
+++ b/src/modules/api/configs/reducers/api.js
@@ -108,6 +108,12 @@ export default function (state = defaultState, action) {
         ...action.customQueryParams,
       };
 
+      Object.keys(action.customQueryParams).forEach(key => {
+        if (newQueryParams[key] === null) {
+          delete newQueryParams[key];
+        }
+      });
+
       return {
         ...state,
         customQueryParams: newQueryParams,

--- a/src/modules/api/configs/reducers/api.js
+++ b/src/modules/api/configs/reducers/api.js
@@ -102,6 +102,18 @@ export default function (state = defaultState, action) {
       };
     }
 
+    case types.SET_QUERY_PARAMS: {
+      const newQueryParams = {
+        ...state.customQueryParams,
+        ...action.customQueryParams,
+      };
+
+      return {
+        ...state,
+        customQueryParams: newQueryParams,
+      };
+    }
+
     default:
       return state;
   }

--- a/src/modules/ui/configs/__tests__/handle_routing.js
+++ b/src/modules/ui/configs/__tests__/handle_routing.js
@@ -2,6 +2,7 @@ import { changeUrl, handleInitialUrl, config } from '../handle_routing';
 import { expect } from 'chai';
 const { describe, it } = global;
 import sinon from 'sinon';
+import qs from 'qs';
 
 describe('manager.ui.config.handle_routing', () => {
   describe('changeUrl', () => {
@@ -17,6 +18,9 @@ describe('manager.ui.config.handle_routing', () => {
         api: {
           selectedKind: 'kk',
           selectedStory: 'ss',
+          customQueryParams: {
+            test: 'teststring',
+          },
         },
         shortcuts: {
           goFullScreen: false,
@@ -33,14 +37,22 @@ describe('manager.ui.config.handle_routing', () => {
         getState: () => reduxState,
       };
 
+      let url = '?selectedKind=kk&selectedStory=ss&full=0&down=1&left=1&panelRight=1&downPanel=pp';
+      const queryString = qs.stringify({ custom: reduxState.api.customQueryParams });
+      url = `${url}&${queryString}`;
+
       const pushState = {
-        url: '?selectedKind=kk&selectedStory=ss&full=0&down=1&left=1&panelRight=1&downPanel=pp',
+        url,
         selectedKind: 'kk',
         selectedStory: 'ss',
         full: false,
         down: true,
         left: true,
         panelRight: true,
+        downPanel: 'pp',
+        custom: {
+          test: 'teststring',
+        },
       };
 
       const originalPushState = window.history.pushState;
@@ -59,6 +71,7 @@ describe('manager.ui.config.handle_routing', () => {
       const actions = {
         api: {
           selectStory: sinon.mock(),
+          setQueryParams: sinon.mock(),
         },
         shortcuts: {
           setLayout: sinon.mock(),
@@ -68,8 +81,11 @@ describe('manager.ui.config.handle_routing', () => {
         },
       };
 
-      const url =
+      let url =
         '?selectedKind=kk&selectedStory=ss&full=1&down=0&left=0&panelRight=0&downPanel=test';
+
+      const queryString = qs.stringify({ custom: { test: 'teststring' } });
+      url = `${url}&${queryString}`;
 
       const location = {
         search: url,
@@ -88,6 +104,7 @@ describe('manager.ui.config.handle_routing', () => {
         downPanelInRight: false,
       })).to.be.true;
       expect(actions.ui.selectDownPanel.calledWith('test')).to.be.true;
+      expect(actions.api.setQueryParams.calledWith({ test: 'teststring' })).to.be.true;
       /* eslint-enable no-unused-expressions */
     });
   });

--- a/src/modules/ui/configs/handle_routing.js
+++ b/src/modules/ui/configs/handle_routing.js
@@ -35,7 +35,12 @@ export function changeUrl(reduxStore) {
 
   const uiQuery = qs.stringify({ downPanel });
 
-  const url = `?${queryString}&${layoutQuery}&${uiQuery}`;
+  const {
+    customQueryParams: custom,
+  } = api;
+  const customParamsString = qs.stringify({ custom });
+
+  const url = `?${queryString}&${layoutQuery}&${uiQuery}&${customParamsString}`;
   const state = {
     url,
     selectedKind,
@@ -44,6 +49,8 @@ export function changeUrl(reduxStore) {
     down,
     left,
     panelRight,
+    downPanel,
+    custom,
   };
 
   window.history.pushState(state, '', url);
@@ -58,6 +65,7 @@ export function updateStore(queryParams, actions) {
     left,
     panelRight,
     downPanel,
+    custom,
   } = queryParams;
 
   if (selectedKind && selectedStory) {
@@ -72,6 +80,7 @@ export function updateStore(queryParams, actions) {
   });
 
   actions.ui.selectDownPanel(downPanel);
+  actions.api.setQueryParams(custom);
 }
 
 export function handleInitialUrl(actions, location) {


### PR DESCRIPTION
The two methods can be used by a provider to save and read state in the url
in the form of url params.