### PR TITLE
Avoid adding custom query params to the state if its undefined

### DIFF
--- a/src/modules/ui/configs/handle_routing.js
+++ b/src/modules/ui/configs/handle_routing.js
@@ -40,7 +40,11 @@ export function changeUrl(reduxStore) {
   } = api;
   const customParamsString = qs.stringify({ custom });
 
-  const url = `?${queryString}&${layoutQuery}&${uiQuery}&${customParamsString}`;
+  let url = `?${queryString}&${layoutQuery}&${uiQuery}`;
+  if (customParamsString) {
+    url = `${url}&${customParamsString}`;
+  }
+
   const state = {
     url,
     selectedKind,
@@ -80,7 +84,9 @@ export function updateStore(queryParams, actions) {
   });
 
   actions.ui.selectDownPanel(downPanel);
-  actions.api.setQueryParams(custom);
+  if (custom) {
+    actions.api.setQueryParams(custom);
+  }
 }
 
 export function handleInitialUrl(actions, location) {


### PR DESCRIPTION
When custom parameters are not set by any addon a single `&` is added to the url and `undefined` is added to the custom field in reduxStore. This avoids them. 