### PR TITLE
Render all the panels but none selected panels has display:none

### DIFF
--- a/src/modules/ui/components/down_panel/__tests__/index.js
+++ b/src/modules/ui/components/down_panel/__tests__/index.js
@@ -6,16 +6,16 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 
 describe('manager.ui.components.down_panel.index', () => {
-  it('should render only the selected panel', () => {
+  it('should render only the selected panel with display set other than "none"', () => {
     const panels = {
       test1: {
         render() {
-          return <div>TEST 1</div>;
+          return <div id="test1">TEST 1</div>;
         },
       },
       test2: {
         render() {
-          return <div>TEST 2</div>;
+          return <div id="test2">TEST 2</div>;
         },
       },
     };
@@ -30,8 +30,8 @@ describe('manager.ui.components.down_panel.index', () => {
       />
     );
 
-    expect(wrapper.contains('TEST 2')).to.equal(true);
-    expect(wrapper.contains('TEST 1')).to.equal(false);
+    expect(wrapper.find('#test1').parent().props().style.display).to.equal('none');
+    expect(wrapper.find('#test2').parent().props().style.display).to.not.equal('none');
   });
 
   it('should set onPanelSelected as onClick handlers of tabs', () => {

--- a/src/modules/ui/components/down_panel/index.js
+++ b/src/modules/ui/components/down_panel/index.js
@@ -34,10 +34,15 @@ class DownPanel extends Component {
     });
   }
 
-  renderPanel() {
-    const panelStyle = { flex: 1, display: 'flex' };
-    const panel = this.props.panels[this.props.selectedPanel];
-    return <div key={name} style={panelStyle}>{panel.render()}</div>;
+  renderPanels() {
+    return Object.keys(this.props.panels).sort().map(name => {
+      const panelStyle = { display: 'none' };
+      const panel = this.props.panels[name];
+      if (name === this.props.selectedPanel) {
+        Object.assign(panelStyle, { flex: 1, display: 'flex' });
+      }
+      return <div key={name} style={panelStyle}>{panel.render()}</div>;
+    });
   }
 
   renderEmpty() {
@@ -55,7 +60,7 @@ class DownPanel extends Component {
     return (
       <div style={style.wrapper}>
         <div style={style.tabbar}>{this.renderTabs()}</div>
-        <div style={style.content}>{this.renderPanel()}</div>
+        <div style={style.content}>{this.renderPanels()}</div>
       </div>
     );
   }


### PR DESCRIPTION
When only the selected panel rendered, when panels are changed they always gets unmounted recreated and re-mounted. This will avoid it and once a panel is mounted at the beginning it will be there forever. So the changes made to a panel is not lost when changing panels.

This is how it was done originally, but I changed it [here](https://github.com/kadirahq/storybook-ui/commit/5e03d1d097654157094a88bb5056874fb7652171#diff-b096eb70fcb35cf872abc5915ba9f81fL46) without realizing what it did :( This PR undo it.
