### PR TITLE
Call onStory when adding a new listener

### DIFF
--- a/dist/modules/api/configs/init_api.js
+++ b/dist/modules/api/configs/init_api.js
@@ -6,10 +6,17 @@ Object.defineProperty(exports, "__esModule", {
 
 exports.default = function (provider, reduxStore, actions) {
   var callbacks = new _events.EventEmitter();
+  var currentKind = void 0;
+  var currentStory = void 0;
 
   var providerApi = {
     onStory: function onStory(cb) {
       callbacks.on('story', cb);
+      if (currentKind && currentStory) {
+        setTimeout(function () {
+          return cb(currentKind, currentStory);
+        }, 0);
+      }
       return function stopListening() {
         callbacks.removeListener('story', cb);
       };
@@ -37,8 +44,6 @@ exports.default = function (provider, reduxStore, actions) {
   provider.handleAPI(providerApi);
 
   // subscribe to redux store and trigger onStory's callback
-  var currentKind = void 0;
-  var currentStory = void 0;
   reduxStore.subscribe(function () {
     var _reduxStore$getState2 = reduxStore.getState();
 

--- a/dist/modules/api/configs/init_api.js
+++ b/dist/modules/api/configs/init_api.js
@@ -13,6 +13,9 @@ exports.default = function (provider, reduxStore, actions) {
     onStory: function onStory(cb) {
       callbacks.on('story', cb);
       if (currentKind && currentStory) {
+        // Using a setTimeout to call the callback to make sure it's
+        // not called on current event-loop. When users add callbacks
+        // they usually expect it to be called in a future event loop.
         setTimeout(function () {
           return cb(currentKind, currentStory);
         }, 0);

--- a/src/modules/api/configs/init_api.js
+++ b/src/modules/api/configs/init_api.js
@@ -2,10 +2,15 @@ import { EventEmitter } from 'events';
 
 export default function (provider, reduxStore, actions) {
   const callbacks = new EventEmitter();
+  let currentKind;
+  let currentStory;
 
   const providerApi = {
     onStory(cb) {
       callbacks.on('story', cb);
+      if (currentKind && currentStory) {
+        setTimeout(() => cb(currentKind, currentStory), 0);
+      }
       return function stopListening() {
         callbacks.removeListener('story', cb);
       };
@@ -29,8 +34,6 @@ export default function (provider, reduxStore, actions) {
   provider.handleAPI(providerApi);
 
   // subscribe to redux store and trigger onStory's callback
-  let currentKind;
-  let currentStory;
   reduxStore.subscribe(function () {
     const { api } = reduxStore.getState();
     if (!api) return;

--- a/src/modules/api/configs/init_api.js
+++ b/src/modules/api/configs/init_api.js
@@ -9,6 +9,9 @@ export default function (provider, reduxStore, actions) {
     onStory(cb) {
       callbacks.on('story', cb);
       if (currentKind && currentStory) {
+        // Using a setTimeout to call the callback to make sure it's
+        // not called on current event-loop. When users add callbacks
+        // they usually expect it to be called in a future event loop.
         setTimeout(() => cb(currentKind, currentStory), 0);
       }
       return function stopListening() {


### PR DESCRIPTION
When a new onStory listener is added, it will only receive story changes. With this PR, listeners will also receive the active kind/story.